### PR TITLE
Update the project to support null-safety

### DIFF
--- a/lib/src/julian.dart
+++ b/lib/src/julian.dart
@@ -33,7 +33,7 @@ Calendar jdToCalendar(num jd) {
   final modfResult = base.modf(jd + .5);
   final z = modfResult.intPart;
   var a = z;
-  var alpha;
+  int alpha;
   if (z >= 2299151) {
     alpha = base.floorDiv(z * 100 - 186721625, 3652425);
     a = z + 1 + alpha - base.floorDiv(alpha, 4);

--- a/lib/src/moonmaxdec.dart
+++ b/lib/src/moonmaxdec.dart
@@ -38,7 +38,7 @@ const _p = math.pi / 180;
 
 Declination _max(num y, _Mc c) {
   var k = (y - 2000.03) * 13.3686; // (52.1) p. 367
-  k = (k + .5).floor();
+  k = (k + .5).floor() as double;
   const ck = 1 / 1336.86;
   final T = k * ck;
   final D = base
@@ -149,7 +149,14 @@ class _Mc {
   final List<num> dc;
 
   const _Mc(
-      {this.D, this.M, this.M_, this.F, this.JDE, this.s, this.tc, this.dc});
+      {required this.D,
+      required this.M,
+      required this.M_,
+      required this.F,
+      required this.JDE,
+      required this.s,
+      required this.tc,
+      required this.dc});
 }
 
 // north coefficients

--- a/lib/src/moonnode.dart
+++ b/lib/src/moonnode.dart
@@ -27,7 +27,7 @@ num descending(num year) {
 }
 
 num _node(num y, num h) {
-  var k = (y - 2000.05) * 13.4223; // (50.1) p. 355
+  num k = (y - 2000.05) * 13.4223; // (50.1) p. 355
   k = (k - h + .5).floor() + h; // snap to half orbit
   const p = math.pi / 180;
   const ck = 1 / 1342.23;

--- a/lib/src/moonphase.dart
+++ b/lib/src/moonphase.dart
@@ -94,11 +94,11 @@ num last(num year) {
 }
 
 class _MoonPhase {
-  num k, T;
-  num E, M, MPrime, F, omega;
-  List<num> A = List(14);
+  late num k, T;
+  late num E, M, MPrime, F, omega;
+  List<num> A = List.filled(14, 0);
 
-  _MoonPhase({this.k});
+  _MoonPhase({required this.k});
 
   /// new or full corrections
   num _nfc(List<num> c) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,11 @@ version: 0.2.2
 homepage: https://github.com/shawnlauzon/meeus
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   unit: ^1.0.1
 
 dev_dependencies:
-  pedantic: ^1.8.0
-  test: ^1.6.0
+  pedantic: ^1.11.1
+  test: ^1.17.12


### PR DESCRIPTION
Support for null-safety.

There is a pull request https://github.com/shawnlauzon/unit/pull/1 to update the `unit` package used in Meeus, in the meantime, we can override the dependency:

```yaml
dependency_overrides:
  unit:
    git:
      url: git://github.com/palmsnipe/unit.git
      ref: patch-1
```